### PR TITLE
Fix total card styling and amount parsing

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
           </h3>
           <p id="expenseDisplay">R$ 2.000,00</p>
         </div>
-        <div class="card total" class="description">
+        <div class="card total">
           <h3>
             <span>Total</span>
             <img src="./assets/total.svg" alt="imagem do total" />

--- a/script.js
+++ b/script.js
@@ -96,9 +96,9 @@ const DOM = {
 const Utils = {
     
     formatAmount(value) {
-        value = Number(value) * 100 
-        console.log(value)
-        return value;
+        value = String(value).replace(',', '.');
+        value = Number(value) * 100;
+        return Math.round(value);
     },
 
     formatDate(date) {


### PR DESCRIPTION
## Summary
- fix total card class attribute so green background appears
- support comma decimal values in `formatAmount`

## Testing
- `node - <<'NODE'
const utils = {formatAmount(value){value=String(value).replace(',', '.');value=Number(value)*100;return Math.round(value);}};
console.log(utils.formatAmount('12,34'));
console.log(utils.formatAmount('12.34'));
console.log(utils.formatAmount('-12,34'));
NODE`


------
https://chatgpt.com/codex/tasks/task_e_687e670bc0f0832b8fff350efe6af4d5